### PR TITLE
OS-75768 update k8s external-secret chart addon

### DIFF
--- a/helm-charts/templates/aftermath-armada-secret.yaml
+++ b/helm-charts/templates/aftermath-armada-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: e2e-flags-secret-optibus-integrations


### PR DESCRIPTION
external-secrets.io/v1beta1 → external-secrets.io/v1
Need to search in all repos (not just armada): [GitHub](https://github.com/search?q=org%3AOptibus++external-secrets.io%2Fv1beta1+&type=code) 
to be done after OS-73609: Production cluster 1.33
Closed
 
See here: [Release helm-chart-0.17.0 · external-secrets/external-secrets](https://github.com/external-secrets/external-secrets/releases/tag/helm-chart-0.17.0)